### PR TITLE
Remove skipping < Python 3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 0378854496c0b46b1c6ea422c32ff2dd93115176bd0c9e5563e75973b015da10
 
 build:
-  number: 6
-  skip: true  # [py<36]
+  number: 7
 
 requirements:
   build:


### PR DESCRIPTION
Since conda-forge does not build against 3.6 anymore.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
